### PR TITLE
Fix bugs in documentation Action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Update output file name to explicitly specify `submodules`
 - Update documentation action to use tags and 'development' versions
 
+### Fixed
+- No longer fail on missing `gh-pages` branch
+- No longer fail on relative links to directories
+
 ---
 
 ## [1.0.0-rc.1] - 2022-08-22

--- a/build-and-deploy-docs/action.py
+++ b/build-and-deploy-docs/action.py
@@ -115,7 +115,11 @@ def setup_git():
         ])
 
     # https://github.com/jimporter/mike/tree/af47b9699aeeeea7f9ecea2631e1c9cfd92e06af#deploying-via-ci
-    subprocess.check_call(["git", "fetch", "origin", "gh-pages", "--depth=1"])
+    # This can fail if the branch doesn't exist yet, so tolerate problems
+    subprocess.run(
+        ["git", "fetch", "origin", "gh-pages", "--depth=1"],
+        check=False
+    )
 
     # Fetch all of the tags as well
     subprocess.check_call(["git", "fetch", "--tags"])

--- a/build-and-deploy-docs/create_mkdocs_config.py
+++ b/build-and-deploy-docs/create_mkdocs_config.py
@@ -185,7 +185,8 @@ def split_readme(readme_file: Path,
                     )
 
                 # If the link is to an image, copy that image to the docs
-                elif magic.from_file(resolved_path, mime=True) \
+                elif resolved_path.is_file() and \
+                        magic.from_file(resolved_path, mime=True) \
                         in VALID_IMAGE_MIME_TYPES:
                     output_path = Path(img_dir, resolved_path.name)
                     shutil.copy2(resolved_path, output_path)


### PR DESCRIPTION
# Description
Of course, of course, these problems only appear in the wild and _not_ during my testing. This PR fixes two issues with the documentation Action I discovered after https://github.com/uclahs-cds/pipeline-recalibrate-BAM/pull/53:

1. In trying to prevent [mike being out-of-date](https://github.com/jimporter/mike?tab=readme-ov-file#deploying-via-ci) with GitHub's copy of the `gh-pages` branch, I added `git fetch origin gh-pages`. That fails if the branch doesn't exist yet.
2. `magic.from_file` only works with files, so any links to directories (like in [this section](https://github.com/uclahs-cds/pipeline-recalibrate-BAM/tree/ee2aab3b41471014bb3267d6955e0ac74ab544b9?tab=readme-ov-file#how-to-run)) cause it to choke.

This fixes those two problems.

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

