### PR TITLE
Update documentation URLs for tags, add script to backfill docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 ### Added
 - Action to build and deploy documentation on GitHub Pages
+- `backfill.py` script to generate documentation for existing tags
 
 ### Changed
 - Update output file name to explicitly specify `submodules`
 - Update documentation action to use tags and 'development' versions
+- Improved GitHub links in documentation links for tagged versions
 
 ### Fixed
 - No longer fail on missing `gh-pages` branch

--- a/build-and-deploy-docs/action.py
+++ b/build-and-deploy-docs/action.py
@@ -27,7 +27,7 @@ TAG_REGEX = re.compile(r"""
     (?:                     # Optional `git describe` addition
         -(?P<depth>\d+)     #   Commits since last tag
         -g(?P<hash>\w+)     #   Commit hash
-    )?
+    )?$
     """, re.VERBOSE)
 
 

--- a/build-and-deploy-docs/backfill.py
+++ b/build-and-deploy-docs/backfill.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"Backfill documentation for existing tags."
+import argparse
+import contextlib
+import functools
+import getpass
+import re
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+from action import TAG_REGEX, strings_low_key
+
+
+def checkrun(*args, context, **kwargs):
+    "A wrapper around subprocess.run to handle common errors."
+    kwargs["check"] = True
+    kwargs["capture_output"] = True
+
+    try:
+        return subprocess.run(*args, **kwargs)
+    except subprocess.CalledProcessError as err:
+        print(f"Error while {context}")
+        print("cmd:", err.cmd)
+        print("stdout:", err.stdout)
+        print("stderr:", err.stderr)
+        raise
+
+
+class Repository:
+    "A GitHub repository."
+    def __init__(self, url: str):
+        self.url = url
+        self.path = None
+        self._tempdir = None
+
+        self.org_repo = re.match(
+            r"^git@github\.com:(.*)\.git$",
+            self.url
+        ).group(1)
+
+    def __enter__(self):
+        self._tempdir = tempfile.TemporaryDirectory()
+        self.path = Path(self._tempdir.name)
+        print(f"Cloning repository into {self.path} ...")
+        checkrun(
+            ["git", "clone", "--recurse-submodules", self.url, self.path],
+            context=f"cloning repository {self.url}"
+        )
+
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self._tempdir.cleanup()
+        self._tempdir = None
+
+    def get_ordered_tags(self):
+        "Get a list of the ordered tags in this repository."
+        all_tags = subprocess.check_output(
+            ["git", "tag"],
+            cwd=self.path
+        ).strip().decode("utf-8").splitlines()
+
+        valid_tags = list(tag for tag in all_tags if TAG_REGEX.match(tag))
+        valid_tags.sort(key=strings_low_key)
+        return valid_tags
+
+    def generate_docs(self, commit: str, image: str):
+        "Generate the documentation for this commit."
+        with contextlib.chdir(self.path):
+            print(f"Generating docs for tag `{commit}`")
+            checkrun(
+                ["git", "checkout", commit],
+                context=f"checking out {commit}"
+            )
+            checkrun(
+                ["git", "clean", "-d", "-x", "--force"],
+                context="cleaning repository"
+            )
+            checkrun(
+                ["git", "submodule", "update", "--init", "--recursive"],
+                context="updating submodules"
+            )
+
+        # Let the filesystem settle... I was running into strange
+        # FileNotFoundErrors, and adding this seems to prevent them.
+        time.sleep(1)
+
+        checkrun(
+            [
+                "docker",
+                "run",
+                "-v", f"{self.path}:{self.path}",
+                "-e", f"GITHUB_REPOSITORY={self.org_repo}",
+                "-e", f"GITHUB_WORKSPACE={self.path}",
+                "-e", f"GITHUB_SHA={commit}",
+                "-e", "BACKFILL_TAGS=1",
+                "-e", "CI=1",
+                "-e", "GITHUB_ACTIONS=1",
+                "-e", f"GITHUB_ACTOR={getpass.getuser()}",
+                "-w", self.path,
+                "--rm",
+                image,
+                "None",
+                "README.md"
+            ],
+            context="generating documentation commit"
+        )
+
+
+# https://gist.github.com/gurunars/4470c97c916e7b3c4731469c69671d06
+def confirm(message):
+    """
+    Ask user to enter Y or N (case-insensitive).
+    :return: True if the answer is Y.
+    :rtype: bool
+    """
+    answer = ""
+    # Requiring a full "yes" or "no" is heavy-handed, but as it's the only
+    # layer of confirmation I'm okay with that
+    while answer not in ["yes", "no"]:
+        try:
+            answer = input(f"{message} [yes/no]? ").lower()
+        except KeyboardInterrupt:
+            print("Treating Ctrl-C as a no...")
+            answer = "no"
+
+    return answer == "yes"
+
+
+def backfill_tag_docs(pipeline_url: str):
+    "Backfill all of the tag documentation for a repository."
+    image = "ghaction"
+
+    checkrun(
+        ["docker", "build", ".", "-t", image],
+        context="building Docker image"
+    )
+
+    with Repository(pipeline_url) as repo:
+        for tag in repo.get_ordered_tags():
+            repo.generate_docs(tag, image)
+
+        with subprocess.Popen(
+                    ["mike", "serve"],
+                    cwd=repo.path,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL) as server:
+            try:
+                print("Updated documentation at http://localhost:8000/")
+                if confirm("Push these docs live"):
+                    subprocess.check_call(
+                        ["git", "push", "origin", "ghpages"],
+                        cwd=repo.path
+                    )
+                else:
+                    print("Not pushing docs")
+            finally:
+                print("Stopping server...")
+                server.terminate()
+                try:
+                    server.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    print("Timeout expired, killing server...")
+                    server.kill()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("repo_url")
+    args = parser.parse_args()
+
+    backfill_tag_docs(args.repo_url)

--- a/build-and-deploy-docs/backfill.py
+++ b/build-and-deploy-docs/backfill.py
@@ -2,7 +2,6 @@
 "Backfill documentation for existing tags."
 import argparse
 import contextlib
-import functools
 import getpass
 import re
 import subprocess
@@ -15,11 +14,11 @@ from action import TAG_REGEX, strings_low_key
 
 def checkrun(*args, context, **kwargs):
     "A wrapper around subprocess.run to handle common errors."
-    kwargs["check"] = True
-    kwargs["capture_output"] = True
+    kwargs.pop("check", None)
+    kwargs.pop("capture_output", None)
 
     try:
-        return subprocess.run(*args, **kwargs)
+        return subprocess.run(*args, **kwargs, check=True, capture_output=True)
     except subprocess.CalledProcessError as err:
         print(f"Error while {context}")
         print("cmd:", err.cmd)
@@ -166,9 +165,14 @@ def backfill_tag_docs(pipeline_url: str):
                     server.kill()
 
 
-if __name__ == "__main__":
+def main():
+    "The main entrypoint."
     parser = argparse.ArgumentParser()
     parser.add_argument("repo_url")
     args = parser.parse_args()
 
     backfill_tag_docs(args.repo_url)
+
+
+if __name__ == "__main__":
+    main()

--- a/build-and-deploy-docs/create_mkdocs_config.py
+++ b/build-and-deploy-docs/create_mkdocs_config.py
@@ -7,10 +7,12 @@ for MKDocs to render.
 """
 import argparse
 import collections
+import contextlib
 import itertools
 import os
 import re
 import shutil
+import tempfile
 
 from urllib.parse import urlparse, urlunparse
 from dataclasses import dataclass, field
@@ -347,6 +349,22 @@ def build_mkdocs_config(pipeline_dir: Path,
             sort_keys=False)
 
     return output_config
+
+
+@contextlib.contextmanager
+def inherited_config(config_file: Path, overrides: dict) -> Path:
+    """
+    Create an inherited MkDocs configuration file to override specific values.
+    """
+    with tempfile.NamedTemporaryFile(mode="w",
+                                     dir=config_file.parent) as temp_config:
+        yaml.safe_dump(
+            {"INHERIT": config_file.name, **overrides},
+            temp_config,
+            explicit_start=True,
+            sort_keys=False)
+
+        yield Path(temp_config.name)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Description
Okay, I should be done with this action after this. There are two related things happening with this PR:

## Script to backfill docs for existing tags

The first change in this PR is to add a script that clones a pipeline, builds the documentation for each tag, previews it for you locally, and gives you the opportunity to push the changes up to GitHub.

```console
$ ./backfill.py git@github.com:uclahs-cds/pipeline-align-DNA.git
Cloning repository into /var/folders/q5/pzb2r_1s01l6gvysk3cglxm4wpvxcb/T/tmp0967bgod ...
Generating docs for tag `v3.0.0`
Generating docs for tag `v5.0.0`
Generating docs for tag `v6.0.0`
Generating docs for tag `v6.0.1`
Generating docs for tag `v6.0.2`
Generating docs for tag `v6.1.0`
Generating docs for tag `v7.0.0`
Generating docs for tag `v7.0.1`
Generating docs for tag `v7.0.2`
Generating docs for tag `v7.0.3`
Generating docs for tag `v7.1.0`
Generating docs for tag `v7.2.0`
Generating docs for tag `v7.2.1`
Generating docs for tag `v7.3.0`
Generating docs for tag `v7.3.1`
Generating docs for tag `v8.0.0`
Generating docs for tag `v8.1.0`
Generating docs for tag `v9.0.0`
Generating docs for tag `v10.0.0-rc.1`
Updated documentation at http://localhost:8000/
Push these docs live [yes/no]? no
Not pushing docs
Stopping server...
```

I already ran this script for pipeline-recalibrate-BAM and pushed the changes up (https://improved-bassoon-j5jkeer.pages.github.io/release-candidate/), and in doing so discovered a few things I wanted to improve. Those fixes are the second half of this PR discussed below.

## Updated repository and edit links

There are two links to GitHub on each docs page: an "**Edit on GitHub**" link in the upper right, and a "**GitHub**" link in the lower left.

Currently the "**Edit on GitHub**" link always refers to the version's commit hash, like <https://github.com/uclahs-cds/pipeline-align-DNA/blob/023fdba7e1a875e6893e40d5fc7609c51ef12118/README.md>. The "GitHub" link always points to the main page, like <https://github.com/uclahs-cds/pipeline-align-DNA>.

This change makes it so that tagged versions have better contextual links, like <https://github.com/uclahs-cds/pipeline-align-DNA/blob/v9.0.0/README.md> and <https://github.com/uclahs-cds/pipeline-align-DNA/tree/v9.0.0>. The two advantages there are:
* The GitHub UI will show the actual tag instead of the commit it references (it's _very_ hard to discover what tags point to a commit from the UI).
* The "**GitHub**" link in the lower left will now link to the repository as of that tag, not the main page. The `development` release will still point to the main page. 

### Before
(I know, the hashes don't match, `development` and `v9.0.0` aren't actually the same commit.)
<img width="792" alt="SCR-20240228-okip" src="https://github.com/uclahs-cds/tool-Nextflow-action/assets/829731/f59e7cff-cc28-4c5b-9fb3-140cc5f0f23b">

<img width="750" alt="Screenshot 2024-02-28 at 4 31 11 PM" src="https://github.com/uclahs-cds/tool-Nextflow-action/assets/829731/c5f7c7dd-c624-4e85-a7b5-92b82e78f0ce">


### After
<img width="793" alt="SCR-20240228-ojkm" src="https://github.com/uclahs-cds/tool-Nextflow-action/assets/829731/f73d2add-27e2-487d-b60c-9a8b4723d706">

<img width="750" alt="Screenshot 2024-02-28 at 4 31 21 PM" src="https://github.com/uclahs-cds/tool-Nextflow-action/assets/829731/e45a24f7-0a15-4a17-a8df-0717faeaf3a8">

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.