### PR TITLE
Fix bugs in documentation generation workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - No longer fail on relative links to directories
 - No longer fail on broken links
 - Properly format headings with embedded markdown
+- Handle constructing anchor links for repeated headings
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 - No longer fail on missing `gh-pages` branch
 - No longer fail on relative links to directories
+- No longer fail on broken links
+- Properly format headings with embedded markdown
 
 ---
 

--- a/build-and-deploy-docs/backfill.py
+++ b/build-and-deploy-docs/backfill.py
@@ -22,8 +22,8 @@ def checkrun(*args, context, **kwargs):
     except subprocess.CalledProcessError as err:
         print(f"Error while {context}")
         print("cmd:", err.cmd)
-        print("stdout:", err.stdout)
-        print("stderr:", err.stderr)
+        print("stdout:", err.stdout.decode("utf-8"))
+        print("stderr:", err.stderr.decode("utf-8"))
         raise
 
 
@@ -150,7 +150,7 @@ def backfill_tag_docs(pipeline_url: str):
                 print("Updated documentation at http://localhost:8000/")
                 if confirm("Push these docs live"):
                     subprocess.check_call(
-                        ["git", "push", "origin", "ghpages"],
+                        ["git", "push", "origin", "gh-pages"],
                         cwd=repo.path
                     )
                 else:

--- a/build-and-deploy-docs/create_mkdocs_config.py
+++ b/build-and-deploy-docs/create_mkdocs_config.py
@@ -82,6 +82,34 @@ def parse_args():
     return parser.parse_args()
 
 
+def strip_markdown(text):
+    """
+    Strip away all Markdown formatting in this inline text.
+    """
+    renderer = MarkdownIt("gfm-like")
+
+    def render_code_inline(_renderer, tokens, i, _options, _env):
+        "Render just the content of the code block."
+        return tokens[i].content
+
+    renderer.add_render_rule("code_inline", render_code_inline)
+
+    def render_nothing(*_):
+        "Render nothing for offending tags."
+        return ""
+
+    # Ignore the following format styles:
+    #   **bold text** <strong>
+    #   [linked text](example.com) <link>
+    #   _italic text_ <em>
+    #   ~~struck text~~ <s>
+    for ignore_tag in ("strong", "link", "em", "s"):
+        renderer.add_render_rule(f"{ignore_tag}_open", render_nothing)
+        renderer.add_render_rule(f"{ignore_tag}_close", render_nothing)
+
+    return renderer.renderInline(text)
+
+
 def get_heading_anchor(text):
     """
     Return the anchor name GitHub would assign to this heading text.
@@ -89,7 +117,8 @@ def get_heading_anchor(text):
     # Based on https://gist.github.com/asabaylus/3071099, it seems like GitHub
     # replaces spaces with dashes and strips all special characters other than
     # - and _. I can't find an authoritative source confirming these rules.
-    no_spaces = re.sub(r"\s", "-", text.strip())
+    plain_text = strip_markdown(text.strip())
+    no_spaces = re.sub(r"\s", "-", plain_text)
     no_specials = re.sub(r"[^\w_-]", "", no_spaces)
     return no_specials.casefold()
 
@@ -213,9 +242,15 @@ def split_readme(readme_file: Path,
         elif link.fragment:
             # This is an anchor link. As we've split the monolithic README into
             # multiple files, we need to prepend those filepaths.
-            link = link._replace(
-                path=anchor_pages[get_heading_anchor(link.fragment)],
-            )
+            try:
+                link = link._replace(
+                    path=anchor_pages[get_heading_anchor(link.fragment)],
+                )
+            except KeyError:
+                # Well, the link seems broken, so just leave it broken, but add
+                # a GitHub warning annotation
+                print("::warning title=Broken Link::", end="")
+                print(f"Broken anchor link {link.fragment}")
 
         return urlunparse(link)
 
@@ -250,7 +285,9 @@ def split_readme(readme_file: Path,
             encoding="utf-8"
         )
 
-        table_of_contents.append({page.title: page.get_filename()})
+        table_of_contents.append(
+            {strip_markdown(page.title): page.get_filename()}
+        )
 
     return table_of_contents
 

--- a/build-and-deploy-docs/create_mkdocs_config.py
+++ b/build-and-deploy-docs/create_mkdocs_config.py
@@ -146,7 +146,7 @@ def split_readme(readme_file: Path,
     Return a list of {<title>: <filename>} dictionaries suitable for a MkDocs
     nav element.
     """
-    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals,too-many-statements
     img_dir = docs_dir / 'img'
 
     docs_dir.mkdir(exist_ok=True)

--- a/build-and-deploy-docs/create_mkdocs_config.py
+++ b/build-and-deploy-docs/create_mkdocs_config.py
@@ -180,8 +180,15 @@ def split_readme(readme_file: Path,
 
             # Associate this anchor with the current page
             anchor = get_heading_anchor(heading_content)
-            assert anchor not in anchor_pages
-            anchor_pages[anchor] = pages[-1].get_filename()
+
+            # Okay, repeated anchors get numbers appended
+            anchor_index = 0
+            constructed_anchor = anchor
+            while constructed_anchor in anchor_pages:
+                anchor_index += 1
+                constructed_anchor = f"{anchor}-{anchor_index}"
+
+            anchor_pages[constructed_anchor] = pages[-1].get_filename()
 
         pages[-1].tokens.append(token)
 


### PR DESCRIPTION
# Description
This fixes four issues with the documentation generation:

1. `backfill.py` tries to push to `ghpages` and not `gh-pages` 🤦 
2. Repeated headings trip an assertion failure
3. Bad anchor links cause the process to crash
    * Sub-issue #19 is that the parsed anchor for a heading with an embedded link is somethink like `please-see-list-of-contributorshttpsgithubcomuclahs-cdspipeline-call-mtsnvgraphscontributors-at-github` instead of `please-see-list-of-contributors-at-github`
    * Older versions of call-mtSNV just have plain ol' broken links in them, like <https://github.com/uclahs-cds/pipeline-call-mtSNV/tree/2.0.0?tab=readme-ov-file#2-Align-mt-Reads-with-MToolBox>
4. Headings with Markdown formatting (links, emphasis, whatever) have that formatting show up in the table of contents:
<img width="1109" alt="Screenshot 2024-03-06 at 3 43 41 PM" src="https://github.com/uclahs-cds/tool-Nextflow-action/assets/829731/96e59889-ea1b-4082-a4cd-ce8f36165c04">



The first problem was a one-character fix.

I walked right into the second problem (#22) by assuming that, because headings get anchor links, they of course must always be unique. Obviously untrue, and GitHub handles that by appending numbers to repeated headings (see [this README](https://github.com/uclahs-cds/user-nwiltsie/tree/01910be68f0eb02f4cb341bcdefa911583e071bc?tab=readme-ov-file#repeated-heading) for an example). The generated docs will now behave the same way, with anchor links `repeat`, `repeat-1`, `repeat-2`, etc.

For the last two problems, I added a `strip_markdown` function that uses some custom rules for a [markdown-it renderer](https://markdown-it-py.readthedocs.io/en/latest/using.html#renderers) to strip away all inline formatting. That function is used for both the anchor links and the page titles - that ensures that the links work as expected, the table of contents looks correct, but the formatting persists on the actual pages:

<img width="1100" alt="Screenshot 2024-03-06 at 3 47 26 PM" src="https://github.com/uclahs-cds/tool-Nextflow-action/assets/829731/f3c4856f-6036-475e-826a-14bbd28917f5">

Finally, actually incorrect anchor links are just left broken. That means that instead of being properly re-written to point to the correct page, like <http://localhost:8000/latest/pipeline-steps/#3-Call-mtSNV-with-mitoCaller>, they are left as bad anchors on the root page, like <http://localhost:8000/latest/#2-Align-mt-Reads-with-MToolBox>. A warning annotation will show up on the workflow run's summary, but nobody will notice unless they specifically go looking for it.
 

### Closes #19, closes #22

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

