### PR TITLE
Add script to run Nextflow configuration regression tests locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `backfill.py` script to generate documentation for existing tags
 - Add reusable workflow to run Nextflow regression tests
 - Add new `nextflow-config-tests` Docker image linked to this repository
+- Add `nfconfigtest` script to run regression tests locally
 
 ### Changed
 - Update output file name to explicitly specify `submodules`

--- a/run-nextflow-tests/Dockerfile
+++ b/run-nextflow-tests/Dockerfile
@@ -28,7 +28,8 @@ RUN yum install -y python3 && \
         nextflow -v && \
     sed \
         $(find /.nextflow/tmp/launcher -name 'classpath-*' -printf '%T@\t%p\n' | sort -n | tail -n1 | cut -f2) \
-        -e 's|"nextflow.cli.Launcher"|"groovy.ui.GroovyMain" "$@"|' >> "$testscript"
+        -e 's|nextflow.cli.Launcher|groovy.ui.GroovyMain|' >> "$testscript" && \
+    echo ' "$@"' >> "$testscript"
 
 # Copy in the `nextflow config`-like groovy script
 COPY betterconfig.groovy /usr/local/bltests/

--- a/run-nextflow-tests/README.md
+++ b/run-nextflow-tests/README.md
@@ -108,3 +108,18 @@ The true Nextflow configuration output is slightly modified for usability:
     * The result of evaluating the closure
     * A map with the closure's code and the results of evaluating it with the additional variables `task.attempt` and `task.cpus` set
     * The static string `closure()`
+
+## Local Usage
+
+Regression tests can be run locally with the [`nfconfigtest`](./nfconfigtest) script included with this repository.
+
+```console
+usage: nfconfigtest [-h] [--dev] [--path repo]
+
+Run the Nextflow configuration regression tests for a specified pipeline.
+
+options:
+  -h, --help   show this help message and exit
+  --dev        Rebuild and use image from the checked-out repository
+  --path repo  Root of the repository to be tested (default: .)
+```

--- a/run-nextflow-tests/README.md
+++ b/run-nextflow-tests/README.md
@@ -53,6 +53,7 @@ jobs:
 ### Example Test
 ```json
 {
+  "nextflow_version": "23.10.0",
   "config": [
     "test/global.config",
     "test/config/gsv_discovery-all-tools.config"

--- a/run-nextflow-tests/entry.py
+++ b/run-nextflow-tests/entry.py
@@ -28,4 +28,6 @@ if __name__ == "__main__":
     if run_pipeline_test(args.pipeline_path.resolve(), args.test_path):
         sys.exit(0)
 
-    sys.exit(1)
+    # Exit with code 82 to indicate that the tests successfully ran but
+    # differences were found
+    sys.exit(82)

--- a/run-nextflow-tests/nfconfigtest
+++ b/run-nextflow-tests/nfconfigtest
@@ -97,13 +97,20 @@ def tidy_docker(image: str,
 
 def run_tests(path: Path, dev_image: bool) -> int:
     "Run the pipeline tests and returns the number of failures."
-    logging.info("Running tests for %s", path.resolve().name)
+    logging.info("Looking for tests in %s", path.resolve().name)
+
     test_files = [
         filepath for filepath in path.glob("**/configtest*.json")
         if not filepath.stem.endswith("-out")
+        and ".mypy_cache" not in filepath.parts
     ]
 
     test_count = len(test_files)
+
+    if test_count == 0:
+        logging.info("No tests found!")
+        return 1
+
     digits = math.ceil(math.log10(test_count))
     success_count = 0
 
@@ -152,7 +159,8 @@ def main() -> None:
 
     parser = argparse.ArgumentParser(
         description="""
-            Run the Nextflow configuration regression tests.
+        Run the Nextflow configuration regression tests for a specified
+        pipeline.
         """
     )
     parser.add_argument(
@@ -171,10 +179,28 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    if not args.path.exists():
-        parser.error(f"{str(args.path)} does not exist")
+    if not args.path.is_dir():
+        parser.error(f"{str(args.path)} is not a directory")
 
-    sys.exit(run_tests(args.path.resolve(), args.dev))
+    # Determine the path to the .git directory
+    user_dir = args.path.resolve()
+
+    try:
+        root_dir = Path(
+            args.path,
+            subprocess.check_output(
+                ["git", "rev-parse", "--git-dir"],
+                cwd=user_dir
+            ).decode("utf-8").strip()
+        ).resolve().parent
+
+    except subprocess.CalledProcessError:
+        parser.error(f"{str(args.path)} is not in a git repository")
+
+    if root_dir != user_dir:
+        logging.info("... adjusting to pipeline root %s", root_dir)
+
+    sys.exit(run_tests(root_dir, args.dev))
 
 
 if __name__ == "__main__":

--- a/run-nextflow-tests/nfconfigtest
+++ b/run-nextflow-tests/nfconfigtest
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"Run the Nextflow configuration regression tests."
+import argparse
+import json
+import logging
+import math
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def build_image(nextflow_version: str) -> str:
+    "Rebuild the local image and return the image name."
+    image_name = f"local-nf-config-{nextflow_version}"
+
+    logging.debug("Rebuilding local image for version %s...", nextflow_version)
+
+    try:
+        subprocess.run(
+            ["docker", "build", ".", "-t", image_name],
+            cwd=Path(__file__).resolve().parent,
+            check=True,
+            capture_output=True,
+        )
+        logging.debug("Done!")
+
+    except subprocess.CalledProcessError as err:
+        logging.error("Failed to build image!")
+        logging.debug(err.stdout.decode("utf-8"))
+        logging.debug(err.stderr.decode("utf-8"))
+        raise
+
+    return image_name
+
+
+def tidy_docker(image: str,
+                pipeline: Path,
+                testfile: Path) -> bool:
+    """
+    Run docker in a self-cleaning way and return the result.
+    """
+    pipeline = pipeline.resolve()
+    testfile = testfile.resolve()
+
+    output_file = testfile.with_name(testfile.stem + "-out.json")
+
+    container_id = subprocess.run(
+        [
+            "docker",
+            "create",
+            "--rm",
+            "-v", f"{pipeline}:{pipeline}",
+            image,
+            pipeline,
+            testfile.resolve()
+        ],
+        capture_output=True,
+        check=True
+    ).stdout.decode("utf-8").strip()
+
+    try:
+        subprocess.run(
+            ["docker", "start", "--attach", container_id],
+            check=True,
+            capture_output=True
+        )
+        # Remove the identical output file
+        output_file.unlink()
+        return True
+
+    except subprocess.CalledProcessError as err:
+        if err.returncode == 82:
+            logging.warning("  Failure")
+            logging.warning(
+                "  Compare these files and copy any expected changes:"
+            )
+            logging.warning("  Original: %s", testfile)
+            logging.warning("  Output:   %s", output_file)
+        else:
+            logging.error("Error running test!")
+            logging.error(err.stdout.decode('utf-8'))
+            logging.error(err.stderr.decode('utf-8'))
+            raise RuntimeError('Error running test!') from err
+    finally:
+        # Due to the the `docker create --rm` flag the container will delete
+        # itself once it stops, so make sure that it does so. This command will
+        # fail if the container has already stopped, so ignore the return code.
+        subprocess.run(
+            ["docker", "stop", container_id],
+            capture_output=True,
+            check=False
+        )
+
+    return False
+
+
+def run_tests(path: Path, dev_image: bool) -> int:
+    "Run the pipeline tests and returns the number of failures."
+    logging.info("Running tests for %s", path.resolve().name)
+    test_files = [
+        filepath for filepath in path.glob("**/configtest*.json")
+        if not filepath.stem.endswith("-out")
+    ]
+
+    test_count = len(test_files)
+    digits = math.ceil(math.log10(test_count))
+    success_count = 0
+
+    log_format = f"#%{digits}d/%d: %s"
+
+    for index, test in enumerate(sorted(test_files)):
+        logging.info(log_format, index+1, test_count, test.relative_to(path))
+
+        # Check the Nextflow version of the test
+        with test.open() as infile:
+            nextflow_version = json.load(infile)["nextflow_version"]
+
+        if nextflow_version != "23.10.0":
+            logging.error(
+                "  ERROR: Only Nextflow version 23.10.0 is supported"
+            )
+            continue
+
+        if dev_image:
+            image_name = build_image(nextflow_version)
+        else:
+            image_name = ":".join([
+                "ghcr.io/uclahs-cds/nextflow-config-tests",
+                nextflow_version
+            ])
+            subprocess.run(
+                ["docker", "pull", image_name],
+                capture_output=True,
+                check=True
+            )
+
+        if tidy_docker(image_name, path, test):
+            logging.info("  Success!")
+            success_count += 1
+
+    logging.info("%d/%d tests passed", success_count, test_count)
+    return test_count - success_count
+
+
+def main() -> None:
+    "Run the Nextflow configuration regression tests."
+    logging.basicConfig(
+        format='%(message)s',
+        level=logging.INFO
+    )
+
+    parser = argparse.ArgumentParser(
+        description="""
+            Run the Nextflow configuration regression tests.
+        """
+    )
+    parser.add_argument(
+        "--dev",
+        action="store_true",
+        help="Rebuild and use image from the checked-out repository"
+    )
+
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=Path(os.curdir),
+        metavar="repo",
+        help="Root of the repository to be tested (default: .)"
+    )
+
+    args = parser.parse_args()
+
+    if not args.path.exists():
+        parser.error(f"{str(args.path)} does not exist")
+
+    sys.exit(run_tests(args.path.resolve(), args.dev))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Description
This PR adds a new `nfconfigtest` script that allows users to run the regression tests locally:

```console
$ ./nfconfigtest --dev --path ~/src/pipeline-recalibrate-BAM/
Looking for tests in pipeline-recalibrate-BAM
#1/2: test/configtest-F16.json
  Failure
  Compare these files and copy any expected changes:
  Original: /Users/nwiltsie/src/pipeline-recalibrate-BAM/test/configtest-F16.json
  Output:   /Users/nwiltsie/src/pipeline-recalibrate-BAM/test/configtest-F16-out.json
#2/2: test/configtest-F32.json
  Success!
1/2 tests passed
```

The script automatically cleans up any of the `-out.json` files that _do_ match the expected results, leaving only the files that a user needs to review.

In addition to the script itself, I changed the `sed` command in the Dockerfile to be a little more robust. The launcher script for Nextflow 24.01.0-edge no longer has double quotes (I'm assuming just to thwart me specifically), so this is just a bit of future-proofing.

```console
$ docker run -it --entrypoint /bin/bash nextflow/nextflow:23.10.0 -c 'grep -o ".\{30\}$" /.nextflow/tmp/launcher/nextflow-one_*/buildkitsandbox/classpath-*' 2>/dev/null
.jar" "nextflow.cli.Launcher"
```

```console
$ docker run -it --entrypoint /bin/bash nextflow/nextflow:24.01.0-edge -c 'grep -o ".\{30\}$" /.nextflow/tmp/launcher/nextflow-one_*/buildkitsandbox/classpath-*' 2>/dev/null
3.0.jar nextflow.cli.Launcher
```

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].

- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

