### PR TITLE
Add capability for more complicated mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Update output file name to explicitly specify `submodules`
 - Update documentation action to use tags and 'development' versions
 - Improved GitHub links in documentation links for tagged versions
+- Add dynamic mocks to Nextflow regression tests
 
 ### Fixed
 - No longer fail on missing `gh-pages` branch

--- a/run-nextflow-tests/README.md
+++ b/run-nextflow-tests/README.md
@@ -31,6 +31,49 @@ Any methods that access files outside of the repository must be listed in `mocks
   }
 ```
 
+### Dynamic Mocks
+
+In very specific circumstances a mock function that returns a static value is insufficient - for example, a pipeline that requires paired input BAMs might check that they have separate sample IDs. That means that this mock...
+
+```json
+  "mocks": {
+    "parse_bam_header": {
+      "read_group": [
+        {
+          "SM": "495723"
+        }
+      ]
+    }
+  }
+```
+
+... would return the same sample ID for each input BAM and thus fail.
+
+To solve this, a dynamic mock like the following may be used:
+
+```json
+  "mocks": {
+    "DYNAMIC|parse_bam_header": {
+      "[\"/hot/software/pipeline/pipeline-SQC-DNA/Nextflow/development/test-input/HG002.N-n2.bam\"]": {
+        "read_group": [
+          {
+            "SM": "098765"
+          }
+        ]
+      },
+      "[\"/hot/software/pipeline/pipeline-SQC-DNA/Nextflow/development/test-input/S2.T-n2.bam\"]": {
+        "read_group": [
+          {
+            "SM": "52345245"
+          }
+        ]
+      }
+    }
+  }
+```
+
+Dynamic mocks have their method name prefixed with `DYNAMIC|`. Their values are maps with JSONified function arguments for keys and static return values as values. Note that the function arguments are always presented as a list, even for a single argument.
+
 ## Usage
 
 ### Workflow File


### PR DESCRIPTION
# Description
This PR adds the capability for more complicated mocks that can return different values depending upon the arguments.

This is specifically to solve handle configs like [this](https://github.com/uclahs-cds/pipeline-generate-SQC-BAM/blob/f0ad5cd56134f4626d83a7c90ceab7641702b354/config/methods.config#L7-L20):

```groovy
methods {
    get_ids_from_bams = {
        params.samples_to_process = [] as Set
        params.input.each { k, v ->
            v.each { sampleMap ->
                def bam_path = sampleMap['path']
                def bam_header = bam_parser.parse_bam_header(bam_path)
                def sm_tags = bam_header['read_group'].collect{ it['SM'] }.unique()
                if (sm_tags.size() != 1) {
                    throw new Exception("${bam_path} contains multiple samples! Please run pipeline with single sample BAMs.")
                }
                if (params.samples_to_process.any { it.orig_id == sm_tags[0] }) {
                    throw new Exception("Sample ${sm_tags[0]} was found in multiple BAMs. Please provide only one BAM per sample")
                }
```

The pipeline accepts paired BAMs, and it performs the reasonable check that those BAMs do not have matching sample IDs. However, our only mockable hook in there is `parse_bam_header`, and returning the same value twice will cause the configuration to fail.

_So_. I'm adding a layer of complexity with "dynamic mocks" that look like this:

```json
  "mocks": {
    "DYNAMIC|parse_bam_header": {
      "[\"/hot/software/pipeline/pipeline-SQC-DNA/Nextflow/development/test-input/HG002.N-n2.bam\"]": {
        "read_group": [
          {
            "SM": "098765"
          }
        ]
      },
      "[\"/hot/software/pipeline/pipeline-SQC-DNA/Nextflow/development/test-input/S2.T-n2.bam\"]": {
        "read_group": [
          {
            "SM": "52345245"
          }
        ]
      }
    }
  }
```

The function name has `DYNAMIC|` prepended to it, and there is another level that maps from the function's arguments to the return value. If the mocked function is called with any other arguments it will report them and fail:

```console
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at betterconfig.print_configuration(betterconfig.groovy:223)
	at betterconfig.run(betterconfig.groovy:241)
Caused by: java.lang.Exception: Dynamic mock parse_bam_header does not contain ["/hot/software/pipeline/pipeline-SQC-DNA/Nextflow/development/test-input/HG002.N-n2.bam"]
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
```

The function arguments are also presented as a JSONified string of an `Object []`. That means that it is _always_ an array, even for zero- or one-argument functions.

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

