### PR TITLE
Update workflow and status check name

### DIFF
--- a/.github/workflows/nextflow-tests.yml
+++ b/.github/workflows/nextflow-tests.yml
@@ -1,5 +1,5 @@
 ---
-name: 'Nextflow tests'
+name: Nextflow config tests
 
 on:
   workflow_call:
@@ -56,7 +56,7 @@ jobs:
                state: "pending",
                target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
                description: "Testing started...",
-               context: "Nextflow tests",
+               context: "Nextflow config tests",
             });
 
       - uses: actions/checkout@v4
@@ -156,7 +156,7 @@ jobs:
                repo: context.repo.repo,
                sha: ${{ toJSON(needs.discover.outputs.review_sha) }},
                target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-               context: "Nextflow tests",
+               context: "Nextflow config tests",
             };
 
             if (tests_failed) {

--- a/.github/workflows/test-setup.yml
+++ b/.github/workflows/test-setup.yml
@@ -237,7 +237,7 @@ jobs:
                sha: config.review_sha,
                state: "pending",
                description: "Tests requested...",
-               context: "Nextflow tests",
+               context: "Nextflow config tests",
             });
 
       - uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Improved GitHub links in documentation links for tagged versions
 - Add dynamic mocks to Nextflow regression tests
 - Resolve permissions issues with Nextflow tests via multiple workflows
+- Rename workflow and status check name to 'Nextflow config tests'
 
 ### Fixed
 - No longer fail on missing `gh-pages` branch


### PR DESCRIPTION
# Description
Per the discussion in https://github.com/uclahs-cds/group-infrastructure/discussions/61, this updates the Nextflow test reusable workflow name to "Nextflow config tests".

The status posted on each commit will also have the name "Nextflow config tests", although there is nothing enforcing that those two names be the same.


# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

