### PR TITLE
Don't include .git folder in release bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Properly format headings with embedded markdown
 - Handle constructing anchor links for repeated headings
 - No longer fail when no Nextflow tests are discovered
+- Do not store GITHUB_TOKEN in release bundle
 
 ---
 

--- a/add-source-with-submodules/action.yml
+++ b/add-source-with-submodules/action.yml
@@ -20,7 +20,7 @@ runs:
         submodules: 'recursive'
         token: ${{ inputs.my-token }}
     - id: create-tar-file
-      uses: uclahs-cds/tool-Nextflow-action/tar-with-submodules@latest
+      uses: uclahs-cds/tool-Nextflow-action/tar-with-submodules@nwiltsie-protect-credentials
       with:
         repository-directory: ${{ steps.repository-path.outputs.repository-path }}
     - name: release

--- a/add-source-with-submodules/action.yml
+++ b/add-source-with-submodules/action.yml
@@ -19,7 +19,6 @@ runs:
         path: ${{ steps.repository-path.outputs.repository-path }}
         submodules: 'recursive'
         token: ${{ inputs.my-token }}
-        persist-credentials: false
     - id: create-tar-file
       uses: uclahs-cds/tool-Nextflow-action/tar-with-submodules@latest
       with:

--- a/add-source-with-submodules/action.yml
+++ b/add-source-with-submodules/action.yml
@@ -14,7 +14,7 @@ runs:
     - id: set-to-https
       shell: bash
       run: echo -e '[url "https://github.com/"]\n  insteadOf = "git@github.com:"' >> ~/.gitconfig
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
       with:
         path: ${{ steps.repository-path.outputs.repository-path }}
         submodules: 'recursive'

--- a/add-source-with-submodules/action.yml
+++ b/add-source-with-submodules/action.yml
@@ -20,7 +20,7 @@ runs:
         submodules: 'recursive'
         token: ${{ inputs.my-token }}
     - id: create-tar-file
-      uses: uclahs-cds/tool-Nextflow-action/tar-with-submodules@nwiltsie-protect-credentials
+      uses: uclahs-cds/tool-Nextflow-action/tar-with-submodules@latest
       with:
         repository-directory: ${{ steps.repository-path.outputs.repository-path }}
     - name: release

--- a/add-source-with-submodules/action.yml
+++ b/add-source-with-submodules/action.yml
@@ -14,11 +14,12 @@ runs:
     - id: set-to-https
       shell: bash
       run: echo -e '[url "https://github.com/"]\n  insteadOf = "git@github.com:"' >> ~/.gitconfig
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: ${{ steps.repository-path.outputs.repository-path }}
         submodules: 'recursive'
         token: ${{ inputs.my-token }}
+        persist-credentials: false
     - id: create-tar-file
       uses: uclahs-cds/tool-Nextflow-action/tar-with-submodules@latest
       with:

--- a/tar-with-submodules/action.yml
+++ b/tar-with-submodules/action.yml
@@ -15,5 +15,5 @@ runs:
     - id: compress-repository
       shell: bash
       run: |
-        tar -czvf source_code_with_submodules.tar.gz ${{ inputs.repository-directory }}
+        tar --exclude-vcs -czvf source_code_with_submodules.tar.gz ${{ inputs.repository-directory }}
         echo "tar-file-path=$(realpath source_code_with_submodules.tar.gz)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Description
This adds the `--exclude-vcs` flag to the `tar` call to exclude `.git`.

Tested with https://github.com/uclahs-cds/user-nwiltsie/actions/runs/8788721695/job/24116987415, resulting in https://github.com/uclahs-cds/user-nwiltsie/releases/tag/v1.0.0-rc.9. The tarball does not include the `.git` folder (please double-check me on that).

Once this is merged we will need to update the `latest` tag.

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

