### PR TITLE
Add ability to mask absolute version numbers in Nextflow tests

### DIFF
--- a/run-nextflow-tests/README.md
+++ b/run-nextflow-tests/README.md
@@ -16,7 +16,8 @@ Configuration tests are self-contained JSON files named `configtest*.json` with 
 | nf_params | A map of command-line parameters to pass to Nextflow (`nextflow --<key>=<value>`) |
 | envvars | A map of environment variables to set (`KEY=VALUE nextflow ...`) |
 | mocks | Method names to be mocked, mapped to the objects they should return |
-| dated_field | A list of JSONPath-like keys indicating values in the rendered configuration that contain datestamps |
+| dated_fields | A list of JSONPath-like keys indicating values in the rendered configuration that contain datestamps |
+| version_fields | A list of JSONPath-like keys indicating values in the rendered configuration that contain the pipeline version number |
 | expected_results | The expected output of the test |
 
 For each test, this Action parses the configuration and runs a modified version of [`nextflow config`](https://www.nextflow.io/docs/latest/cli.html#config), comparing the results against `expected_results` and warning about any differences.
@@ -162,6 +163,7 @@ jobs:
 The true Nextflow configuration output is slightly modified for usability:
 
 * Every field listed in `dated_fields` has timestamps matching the format `YYYYMMDDTHHMMSSZ` replaced with the static value `19970704T165655Z` ([Pathfinder's landing](https://science.nasa.gov/mission/mars-pathfinder/)).
+* Every field listed in `version_fields` has sub-strings matching the `manifest.version` value replaced with the static value `VER.SI.ON`.
 * Every value that looks like a Java object (e.g. `[Ljava.lang.String;@49c7b90e`) has the hash code replaced with the static value `dec0ded`.
     * These should not appear in test files. When they do, it is a sign that the corresponding variable is missing a `def` in the configuration file.
 * Closures are expressed as the first valid item in this list:

--- a/run-nextflow-tests/README.md
+++ b/run-nextflow-tests/README.md
@@ -154,6 +154,14 @@ jobs:
     "trace.file",
     "params.date"
   ],
+  "version_fields": [
+    "manifest.version",
+    "params.log_output_dir",
+    "params.output_dir_base",
+    "report.file",
+    "trace.file",
+    "timeline.file"
+  ],
   "expected_result": {}
 }
 ```

--- a/run-nextflow-tests/configtest.py
+++ b/run-nextflow-tests/configtest.py
@@ -42,6 +42,7 @@ class NextflowConfigTest:
     mocks: Dict
 
     dated_fields: List[str]
+    version_fields: List[str]
 
     expected_result: Dict
 
@@ -54,6 +55,9 @@ class NextflowConfigTest:
         # Remove these deprecated fields
         data.pop("empty_files", None)
         data.pop("mapped_files", None)
+
+        # Bootstrap this new field that may not be present in existing files
+        data.setdefault("version_fields", [])
 
         result = cls(**data)
         result.pipeline = pipeline
@@ -181,7 +185,9 @@ class NextflowConfigTest:
         config_text = config_output.rsplit(self.SENTINEL, maxsplit=1)[-1]
 
         try:
-            return parse_config(config_text, self.dated_fields)
+            return parse_config(
+                config_text, self.dated_fields, self.version_fields
+            )
         except Exception:
             print(config_output)
             raise

--- a/run-nextflow-tests/configtest.py
+++ b/run-nextflow-tests/configtest.py
@@ -214,7 +214,7 @@ class NextflowConfigTest:
             print(config_output)
             raise
 
-    def print_diffs(self, other: T):
+    def print_diffs(self, other: "NextflowConfigTest"):
         "Print the diff results to the console."
         diff_process = subprocess.run(
             ["diff", self.filepath, other.filepath],

--- a/run-nextflow-tests/utils.py
+++ b/run-nextflow-tests/utils.py
@@ -158,7 +158,7 @@ def parse_config(config_str: str,
                  version_fields: List[str]) -> dict:
     "Parse a string of Java properties."
     param_re = re.compile(r"^(?P<key>\S+?[^\\])=(?P<value>.*)$")
-    version_fields = version_fields[:]
+    version_fields = list(version_fields)
 
     def assign_value(closure, key, value):
         if "." not in key:

--- a/run-nextflow-tests/utils.py
+++ b/run-nextflow-tests/utils.py
@@ -181,9 +181,6 @@ def parse_config(config_str: str,
             re.MULTILINE
         ).group(1)
 
-        # Add 'manifest.version' to the list of fields to be masked
-        version_fields.append("manifest.version")
-
     except AttributeError:
         version_str = None
 

--- a/run-nextflow-tests/utils.py
+++ b/run-nextflow-tests/utils.py
@@ -153,9 +153,12 @@ def parse_value(value_str: str) -> Any:
     return value
 
 
-def parse_config(config_str: str, dated_fields: List[str]) -> dict:
+def parse_config(config_str: str,
+                 dated_fields: List[str],
+                 version_fields: List[str]) -> dict:
     "Parse a string of Java properties."
     param_re = re.compile(r"^(?P<key>\S+?[^\\])=(?P<value>.*)$")
+    version_fields = version_fields[:]
 
     def assign_value(closure, key, value):
         if "." not in key:
@@ -169,6 +172,20 @@ def parse_config(config_str: str, dated_fields: List[str]) -> dict:
                 closure[local_key] = {}
 
             assign_value(closure[local_key], remainder, value)
+
+    # Parse out the current manifest version
+    try:
+        version_str = re.search(
+            r"^manifest.version=(.*)$",
+            config_str,
+            re.MULTILINE
+        ).group(1)
+
+        # Add 'manifest.version' to the list of fields to be masked
+        version_fields.append("manifest.version")
+
+    except AttributeError:
+        version_str = None
 
     config: dict[str, Any] = {}
 
@@ -187,6 +204,10 @@ def parse_config(config_str: str, dated_fields: List[str]) -> dict:
         if escaped_key in dated_fields:
             # Replace the date with Pathfinder's landing
             value = DATE_RE.sub("19970704T165655Z", value)
+
+        if escaped_key in version_fields and version_str:
+            # Replace the version with an obvious weird value
+            value = value.replace(version_str, "VER.SI.ON")
 
         assign_value(config, escaped_key, value)
 


### PR DESCRIPTION
# Description
The Nextflow configuration tests have the pipeline's version repeated multiple times in the expected values. That means that any version bump requires updating every test, like with https://github.com/uclahs-cds/pipeline-call-gSV/pull/151#issuecomment-2128076483.

In order to eliminate those kinds of frustrating PRs, this PR adds an optional new `version_fields` parameter for tests. That parameter is (as might be expected) a list of fields that contain the version. Any field listed should also have its embedded version number(s) updated to the string `VER.SI.ON`, like so:

```diff
--- a/test/configtest-F16.json
+++ b/test/configtest-F16.json
@@ -30,6 +30,14 @@
     "trace.file",
     "params.date"
   ],
+  "version_fields": [
+    "manifest.version",
+    "params.log_output_dir",
+    "params.output_dir_base",
+    "report.file",
+    "trace.file",
+    "timeline.file"
+  ],
   "expected_result": {
     "docker": {
       "all_group_ids": "$(for i in `id --real --groups`; do echo -n \"--group-add=$i \"; done)",
@@ -41,7 +49,7 @@
       "author": "Yu Pan, Tim Sanders, Yael Berkovich, Mohammed Faizal Eeman Mootor",
       "description": "A pipeline to call germline structural variants utilizing Delly and Manta",
       "name": "call-gSV",
-      "version": "5.0.0"
+      "version": "VER.SI.ON"
     },
     "params": {
       "GCNV": "gCNV",
@@ -70,7 +78,7 @@
           ]
         }
       },
-      "log_output_dir": "/tmp/test-only-outputs/call-gSV-5.0.0/8675309/log-call-gSV-5.0.0-19970704T165655Z",
+      "log_output_dir": "/tmp/test-only-outputs/call-gSV-VER.SI.ON/8675309/log-call-gSV-VER.SI.ON-19970704T165655Z",
       "manta_version": "1.6.0",
       "map_qual": "20",
       "mappability_map": "/hot/ref/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz",
@@ -79,7 +87,7 @@
       "min_cpus": "1",
       "min_memory": "1 MB",
       "output_dir": "/tmp/test-only-outputs",
-      "output_dir_base": "/tmp/test-only-outputs/call-gSV-5.0.0/8675309",
+      "output_dir_base": "/tmp/test-only-outputs/call-gSV-VER.SI.ON/8675309",
       "pipeval_version": "4.0.0-rc.2",
       "proc_resource_params": {
         "call_gCNV_Delly": {
@@ -368,15 +376,15 @@
     },
     "report": {
       "enabled": true,
-      "file": "/tmp/test-only-outputs/call-gSV-5.0.0/8675309/log-call-gSV-5.0.0-19970704T165655Z/nextflow-log/report.html"
+      "file": "/tmp/test-only-outputs/call-gSV-VER.SI.ON/8675309/log-call-gSV-VER.SI.ON-19970704T165655Z/nextflow-log/report.html"
     },
     "timeline": {
       "enabled": true,
-      "file": "/tmp/test-only-outputs/call-gSV-5.0.0/8675309/log-call-gSV-5.0.0-19970704T165655Z/nextflow-log/timeline.html"
+      "file": "/tmp/test-only-outputs/call-gSV-VER.SI.ON/8675309/log-call-gSV-VER.SI.ON-19970704T165655Z/nextflow-log/timeline.html"
     },
     "trace": {
       "enabled": true,
-      "file": "/tmp/test-only-outputs/call-gSV-5.0.0/8675309/log-call-gSV-5.0.0-19970704T165655Z/nextflow-log/trace.txt"
+      "file": "/tmp/test-only-outputs/call-gSV-VER.SI.ON/8675309/log-call-gSV-VER.SI.ON-19970704T165655Z/nextflow-log/trace.txt"
     },
     "tz": "sun.util.calendar.ZoneInfo[id=\"UTC\",offset=0,dstSavings=0,useDaylight=false,transitions=0,lastRule=null]",
     "workDir": "/scratch/300935"
```

When a test is run, the true/current version number is parsed from the `manifest.version` field of the raw test output. Each field in `version_fields` then has that _exact_ version number replaced with `VER.SI.ON` before the comparison with the expected results.

The effect of that is that the string `VER.SI.ON` always represents one specific version throughout the entire file, even if that specific version is variable. That means that the test in the pipeline-call-gSV example above would not have needed to be modified.

It also means that we'll catch if a version number is incorrectly hard-coded somewhere, e.g. `manifest.version = "1.0.0"; params.randomvar = "pipeline_${manifest.version}/output_1.0.0/"`. If the test JSON were written to assume that both numbers would update, i.e. `"randomvar": "pipeline_VER.SI.ON/output_VER.SI.ON/"`, then _that_ would fail once `manifest.version` was updated to anything other than `1.0.0`.

---

I've tested this locally on pipeline-recalibrate-BAM and pipeline-call-gSV.

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

