### PR TITLE
Update tool-Docker-action to v2.1.0

### DIFF
--- a/.github/workflows/docker-build-release.yaml
+++ b/.github/workflows/docker-build-release.yaml
@@ -30,9 +30,20 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Read YAML
+        id: getversion
+        uses: mikefarah/yq@v4.44.2
+        with:
+          cmd: yq '.nextflow_version' run-nextflow-tests/docker-metadata.yaml    
+      - name: Get date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
       - uses: uclahs-cds/tool-Docker-action@v2.1.0
         with:
           metadata-file: run-nextflow-tests/docker-metadata.yaml
           context: run-nextflow-tests
+          custom-tags: |
+            type=raw,enable=${{github.event_name == 'push' && github.ref == 'refs/heads/main'}},value=${{steps.getversion.outputs.result}}
+            type=raw,enable=${{github.event_name == 'push' && github.ref == 'refs/heads/main'}},value=${{steps.getversion.outputs.result}}-${{steps.date.outputs.date}}
           # Uncomment if you expect to use non-SemVer release tags
           # non-semver-tags: true

--- a/.github/workflows/docker-build-release.yaml
+++ b/.github/workflows/docker-build-release.yaml
@@ -1,43 +1,36 @@
 ---
-name: Build image
+name: Update image in GHCR
 
-# Only rebuild when changes to the run-nextflow-tests/ folder are pushed to
-# main
+run-name: >
+  ${{
+    github.event_name == 'delete' && format(
+      'Delete `{0}{1}`',
+      github.event.ref_type == 'branch' && 'branch-' || '',
+      github.event.ref
+    )
+    || github.ref == 'refs/heads/main' && 'Update `dev`'
+      || format(
+        'Update `{0}{1}`',
+        !startsWith(github.ref, 'refs/tags') && 'branch-' || '',
+        github.ref_name
+      )
+  }} docker tag
+
 on:
   push:
-    branches:
-      - main
-      - nwiltsie-nextflow-regression-action
-    paths:
-      - 'run-nextflow-tests/*'
-      - '.github/workflows/docker-build-release.yaml'
+    branches-ignore: ['gh-pages']
+    tags: ['v*']
+  delete:
 
 jobs:
-  build-and-push-image:
+  push-or-delete-image:
     runs-on: ubuntu-latest
-    name: Build and push image
+    name: Update GitHub Container Registry
     permissions:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
-
-      - id: getversion
-        uses: jbutcher5/read-yaml@1.6
-        with:
-          file: run-nextflow-tests/docker-metadata.yaml
-          key-path: '["nextflow_version"]'
-
-      - name: Get date
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
-
-      - id: build-push
-        uses: uclahs-cds/tool-Docker-action/build-release@main
-        with:
-          metadata-file: run-nextflow-tests/docker-metadata.yaml
-          context: run-nextflow-tests
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          custom-tags: |
-            type=raw,enable=${{github.event_name == 'push'}},value=${{steps.getversion.outputs.data}}
-            type=raw,enable=${{github.event_name == 'push'}},value=${{steps.getversion.outputs.data}}-${{steps.date.outputs.date}}
+      - uses: uclahs-cds/tool-Docker-action@v2.1.0
+      # Uncomment if you expect to use non-SemVer release tags
+      # with:
+      #   non-semver-tags: true

--- a/.github/workflows/docker-build-release.yaml
+++ b/.github/workflows/docker-build-release.yaml
@@ -31,6 +31,8 @@ jobs:
       packages: write
     steps:
       - uses: uclahs-cds/tool-Docker-action@v2.1.0
-      # Uncomment if you expect to use non-SemVer release tags
-      # with:
-      #   non-semver-tags: true
+        with:
+          metadata-file: run-nextflow-tests/docker-metadata.yaml
+          context: run-nextflow-tests
+          # Uncomment if you expect to use non-SemVer release tags
+          # non-semver-tags: true

--- a/.github/workflows/docker-build-release.yaml
+++ b/.github/workflows/docker-build-release.yaml
@@ -35,7 +35,7 @@ jobs:
         id: getversion
         uses: mikefarah/yq@v4.44.2
         with:
-          cmd: yq '.nextflow_version' run-nextflow-tests/docker-metadata.yaml    
+          cmd: yq '.nextflow_version' run-nextflow-tests/docker-metadata.yaml
       - name: Get date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"

--- a/.github/workflows/docker-build-release.yaml
+++ b/.github/workflows/docker-build-release.yaml
@@ -30,6 +30,7 @@ jobs:
       contents: read
       packages: write
     steps:
+      - uses: actions/checkout@v4
       - name: Read YAML
         id: getversion
         uses: mikefarah/yq@v4.44.2


### PR DESCRIPTION
This PR updates the `tool-Docker-action` Action to version 2.1.0. There are a few big changes in this version:

1. Pushing to any branch `foo` will [build this repository's image](https://github.com/uclahs-cds/tool-Docker-action/pull/14) and tag it as `branch-foo`. That tagged image will be removed when the branch is deleted.
1. By default the Action will only build [SemVer](https://semver.org/) tags (e.g. `v1.2.3-xxx`). Repositories that need to use other kinds of tags (e.g. `v1.2beta`) can pass the optional `non-semver-tags` argument; doing so will build all tags that begin with `v`.

There are a bunch of smaller changes buried in there - you can see them all at [this link](https://github.com/uclahs-cds/tool-Docker-action/compare/ebe9f1c...v2.1.0).

Based on this repository's existing tags, I've determined that it _does_ follow semantic versioning. The updated workflow therefore does _not_ pass the `non-semver-tags` argument to the Action, although it can be uncommented in the future if need be.
